### PR TITLE
Store recent items in Appdata folder

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,8 +33,10 @@ dependencies {
 
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
     compile "no.tornado:tornadofx:$tornadoVersion"
-    compile group: 'org.fxmisc.richtext', name: 'richtextfx', version: "$richTextFxVersion"
-    implementation "org.jetbrains.kotlinx:kotlinx-serialization-core:$kotlinxVersion"
+    compile group: 'org.fxmisc.richtext', name: 'richtextfx', version: richTextFxVersion
+    compile group: 'net.harawata', name: 'appdirs', version: appdirsVersion
+    compile group: 'com.moandjiezana.toml', name: 'toml4j', version: toml4jVersion
+    implementation group: 'org.jetbrains.kotlinx', name: 'kotlinx-serialization-core', version: kotlinxVersion
 
     testImplementation "io.kotest:kotest-runner-junit5-jvm:$kotestVersion" // for kotest framework
     testImplementation "io.kotest:kotest-assertions-core-jvm:$kotestVersion" // for kotest core jvm assertions

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,3 +8,5 @@ kotlinxVersion=1.0.0-RC
 richTextFxVersion=1.0.0-SNAPSHOT
 gsonVersion=2.8.5
 kotestVersion=4.2.0.RC2
+appdirsVersion=1.0.3
+toml4jVersion=0.7.2

--- a/src/main/kotlin/JournalApp.kt
+++ b/src/main/kotlin/JournalApp.kt
@@ -5,6 +5,7 @@ import javafx.beans.binding.Bindings
 import javafx.scene.control.ButtonType
 import javafx.scene.control.ButtonType.*
 import javafx.stage.Stage
+import javafx.stage.Window
 import main.kotlin.controller.AppdirController
 import main.kotlin.controller.StoreController
 import main.kotlin.view.MainView
@@ -23,11 +24,37 @@ class JournalApp : App(MainView::class) {
     private val CREDENTIALS_VERSION = "0.0.1"
     private val CREDENTIALS_AUTHOR = "nl.joelabrahams"
 
+    companion object {
+        /**
+         * Show save prompt which blocks owner window, with Yes, No, and Cancel options.
+         *
+         * @return false if cancelled. Useful if we don't wish to continue execution of consecutive actions.
+         */
+        fun savePrompt(storeController: StoreController, owner: Window?): Boolean {
+            if (storeController.journal.isNotNull.get() && storeController.journal.selectBoolean { it.editedProperty }.value) {
+                warning(
+                    header = "Unsaved Changes, do you wish to save first?",
+                    buttons = arrayOf<ButtonType>(YES, NO, CANCEL),
+                    owner = owner,
+                    actionFn = {
+                        when (it) {
+                            YES -> storeController.saveJournal()
+                            NO -> return true
+                            CANCEL -> return false
+                        }
+                    }
+                )
+            }
+            return true
+        }
+    }
+
     override fun start(stage: Stage) {
         val appDirs = AppDirsFactory.getInstance()
         val userConfigDir = appDirs.getUserConfigDir(CREDENTIALS_APP_NAME, CREDENTIALS_VERSION, CREDENTIALS_AUTHOR)
         appdirController.appdir.set(File(userConfigDir))
 
+        super.start(stage)
         stage.titleProperty().bind(
             Bindings.concat(
                 Bindings.`when`(storeController.location.isNotNull)
@@ -39,23 +66,11 @@ class JournalApp : App(MainView::class) {
 
         stage.setOnCloseRequest {
             if (storeController.journal.isNotNull.get() && storeController.journal.selectBoolean { it.editedProperty }.value) {
-                warning(
-                    header = "Journal still open, do you wish to save first?",
-                    buttons = arrayOf<ButtonType>(OK, CANCEL, CLOSE),
-                    owner = stage.owner,
-                    actionFn = { buttonType ->
-                        when (buttonType) {
-                            CANCEL -> it.consume()
-                            OK -> storeController.saveJournal()
-                        }
-                    }
-                )
+                savePrompt(storeController, stage.owner)
             }
-
             appdirController.writeToFile()
         }
 
-        super.start(stage)
     }
 }
 

--- a/src/main/kotlin/JournalApp.kt
+++ b/src/main/kotlin/JournalApp.kt
@@ -5,20 +5,29 @@ import javafx.beans.binding.Bindings
 import javafx.scene.control.ButtonType
 import javafx.scene.control.ButtonType.*
 import javafx.stage.Stage
-import main.kotlin.controller.EditorController
+import main.kotlin.controller.AppdirController
 import main.kotlin.controller.StoreController
 import main.kotlin.view.MainView
+import net.harawata.appdirs.AppDirsFactory
 import tornadofx.App
 import tornadofx.select
 import tornadofx.selectBoolean
 import tornadofx.warning
+import java.io.File
 
 class JournalApp : App(MainView::class) {
     val storeController: StoreController by inject()
-    val editorController: EditorController by inject()
+    val appdirController: AppdirController by inject()
+
+    private val CREDENTIALS_APP_NAME = "AcademicJournal"
+    private val CREDENTIALS_VERSION = "0.0.1"
+    private val CREDENTIALS_AUTHOR = "nl.joelabrahams"
 
     override fun start(stage: Stage) {
-        super.start(stage)
+        val appDirs = AppDirsFactory.getInstance()
+        val userConfigDir = appDirs.getUserConfigDir(CREDENTIALS_APP_NAME, CREDENTIALS_VERSION, CREDENTIALS_AUTHOR)
+        appdirController.appdir.set(File(userConfigDir))
+
         stage.titleProperty().bind(
             Bindings.concat(
                 Bindings.`when`(storeController.location.isNotNull)
@@ -42,9 +51,11 @@ class JournalApp : App(MainView::class) {
                     }
                 )
             }
+
+            appdirController.writeToFile()
         }
 
-        editorController.current.value = storeController.newEntry()
+        super.start(stage)
     }
 }
 

--- a/src/main/kotlin/controller/AppdirController.kt
+++ b/src/main/kotlin/controller/AppdirController.kt
@@ -1,0 +1,58 @@
+package main.kotlin.controller
+
+import com.moandjiezana.toml.Toml
+import com.moandjiezana.toml.TomlWriter
+import javafx.beans.property.SimpleObjectProperty
+import main.kotlin.model.appdir.Files
+import tornadofx.Controller
+import tornadofx.onChange
+import java.io.File
+
+private val FILES = "files.toml"
+
+class AppdirController : Controller() {
+    val storeController: StoreController by inject()
+
+    val appdir = SimpleObjectProperty<File>()
+
+    private var filesFile: File? = null
+
+    val files = SimpleObjectProperty(Files())
+    var writeFilesOnClose = true
+
+    init {
+        appdir.onChange {
+            it?.mkdirs()
+            if (it != null) setup(it)
+        }
+
+        storeController.location.onChange { if (it != null) files.get().addLocation(it) }
+    }
+
+    private fun setup(file: File) {
+        filesFile = File(file, FILES)
+        if (!filesFile!!.exists()) filesFile!!.createNewFile()
+
+        if (filesFile != null && filesFile!!.exists()) {
+            try {
+                files.set(Files.fromToml(Toml().read(filesFile)))
+                if (files.get().lastOpened.isNotNull.get() && storeController.location.isNull.get()) {
+                    storeController.loadJournal(files.get().lastOpened.get().toFile())
+                }
+            } catch (e: RuntimeException) {
+                // TODO use logger
+                e.printStackTrace()
+                // NullPointerException is expected on empty toml file with no opened key
+                if (e !is NullPointerException) writeFilesOnClose = false
+            }
+        }
+    }
+
+    fun writeToFile() {
+        val tomlWriter = TomlWriter()
+
+        if (writeFilesOnClose && files.isNotNull.get() && filesFile != null && filesFile!!.exists()) {
+            tomlWriter.write(files.get().toTomlMap(), filesFile)
+        }
+    }
+}

--- a/src/main/kotlin/controller/AppdirController.kt
+++ b/src/main/kotlin/controller/AppdirController.kt
@@ -1,6 +1,5 @@
 package main.kotlin.controller
 
-import com.moandjiezana.toml.Toml
 import com.moandjiezana.toml.TomlWriter
 import javafx.beans.property.SimpleObjectProperty
 import main.kotlin.model.appdir.Files
@@ -34,16 +33,12 @@ class AppdirController : Controller() {
         if (!filesFile!!.exists()) filesFile!!.createNewFile()
 
         if (filesFile != null && filesFile!!.exists()) {
-            try {
-                files.set(Files.fromToml(Toml().read(filesFile)))
-                if (files.get().lastOpened.isNotNull.get() && storeController.location.isNull.get()) {
-                    storeController.loadJournal(files.get().lastOpened.get().toFile())
-                }
-            } catch (e: RuntimeException) {
-                // TODO use logger
-                e.printStackTrace()
-                // NullPointerException is expected on empty toml file with no opened key
-                if (e !is NullPointerException) writeFilesOnClose = false
+            val fromToml = Files.fromToml(filesFile!!)
+            writeFilesOnClose = fromToml.first
+            files.set(fromToml.second)
+
+            if (files.get().lastOpened.isNotNull.get() && storeController.location.isNull.get()) {
+                storeController.loadJournal(files.get().lastOpened.get().toFile())
             }
         }
     }

--- a/src/main/kotlin/controller/EditorController.kt
+++ b/src/main/kotlin/controller/EditorController.kt
@@ -6,7 +6,7 @@ import main.kotlin.model.JournalEntry
 import tornadofx.Controller
 
 class EditorController : Controller() {
-    val current = SimpleObjectProperty(JournalEntry())
+    val current = SimpleObjectProperty<JournalEntry>()
 
     val editMode = SimpleBooleanProperty()
 }

--- a/src/main/kotlin/controller/StoreController.kt
+++ b/src/main/kotlin/controller/StoreController.kt
@@ -14,6 +14,7 @@ import java.io.File
 class StoreController : Controller() {
     val location = SimpleObjectProperty<File>()
     val journal = SimpleObjectProperty(Journal())
+
     val savedProperty = SimpleBooleanProperty(false)
 
     fun loadJournal(file: File) {

--- a/src/main/kotlin/model/appdir/Files.kt
+++ b/src/main/kotlin/model/appdir/Files.kt
@@ -17,9 +17,20 @@ class Files(opened: List<Path> = listOf()) : Tomable<Files> {
     val recentFiles = SimpleListProperty(opened.toMutableList().toObservable())
 
     companion object {
-        fun fromToml(toml: Toml): Files {
+        /**
+         * Read `*.toml` file and extract items.
+         *
+         * If exception, then log this exception and return false if this is not a NullPointerException,
+         * which is allowed on first boot.
+         */
+        fun fromToml(file: File): Pair<Boolean, Files> = try {
+            val toml = Toml().read(file)
             val opened = toml.getList<String>("opened").map { pathString -> File(pathString).toPath() }
-            return Files(opened)
+            Pair(true, Files(opened))
+        } catch (e: Exception) {
+            // TODO log exception
+            // NullpointerException is allowed on first boot for now
+            Pair(e !is NullPointerException, Files(emptyList()))
         }
     }
 

--- a/src/main/kotlin/model/appdir/Files.kt
+++ b/src/main/kotlin/model/appdir/Files.kt
@@ -1,0 +1,44 @@
+package main.kotlin.model.appdir
+
+import com.moandjiezana.toml.Toml
+import javafx.beans.property.SimpleListProperty
+import javafx.beans.property.SimpleObjectProperty
+import tornadofx.toObservable
+import java.io.File
+import java.nio.file.Path
+
+private val MAX_RECENT = 10
+
+// Escape characters do not work well in TOML
+private val SEPARATOR = "/"
+
+class Files(opened: List<Path> = listOf()) : Tomable<Files> {
+    val lastOpened = SimpleObjectProperty<Path>(if (opened.isEmpty()) null else opened.first())
+    val recentFiles = SimpleListProperty(opened.toMutableList().toObservable())
+
+    companion object {
+        fun fromToml(toml: Toml): Files {
+            val opened = toml.getList<String>("opened").map { pathString -> File(pathString).toPath() }
+            return Files(opened)
+        }
+    }
+
+    fun addLocation(location: File) {
+        val newLocations = recentFiles.toMutableList()
+
+        if (newLocations.isNotEmpty() && newLocations.first() != location.toPath() && location.exists()) {
+            newLocations.add(0, location.toPath())
+        } else if (newLocations.isEmpty() && location.exists()) {
+            newLocations.add(location.toPath())
+        }
+
+        newLocations.dropLastWhile { newLocations.size > MAX_RECENT }
+        this.recentFiles.setAll(newLocations)
+    }
+
+    override fun toTomlMap(): Map<String, *> {
+        val map = HashMap<String, List<String>>()
+        map["opened"] = recentFiles.toList().map { it.toString().replace("\\", SEPARATOR) }
+        return map
+    }
+}

--- a/src/main/kotlin/model/appdir/Files.kt
+++ b/src/main/kotlin/model/appdir/Files.kt
@@ -25,10 +25,12 @@ class Files(opened: List<Path> = listOf()) : Tomable<Files> {
 
     fun addLocation(location: File) {
         val newLocations = recentFiles.toMutableList()
+        // Remove all current locations to prevent duplication
+        newLocations.removeAll { it == location.toPath() }
 
-        if (newLocations.isNotEmpty() && newLocations.first() != location.toPath() && location.exists()) {
+        if (newLocations.isNotEmpty()) {
             newLocations.add(0, location.toPath())
-        } else if (newLocations.isEmpty() && location.exists()) {
+        } else if (newLocations.isEmpty()) {
             newLocations.add(location.toPath())
         }
 

--- a/src/main/kotlin/model/appdir/Tomable.kt
+++ b/src/main/kotlin/model/appdir/Tomable.kt
@@ -1,0 +1,5 @@
+package main.kotlin.model.appdir
+
+interface Tomable<T> {
+    fun toTomlMap(): Map<String, *>
+}

--- a/src/main/kotlin/view/EditorView.kt
+++ b/src/main/kotlin/view/EditorView.kt
@@ -40,7 +40,7 @@ class EditorView : View() {
         hbox {
             circle(radius = 3).visibleWhen(editorController.current.select { it.editedProperty })
             textfield(editorController.current.select { it.titleProperty }) {
-                disableWhen(editorController.editMode.not())
+                disableWhen(editorController.editMode.not().or(editorController.current.isNull))
             }
         }
         hbox {
@@ -50,7 +50,7 @@ class EditorView : View() {
         }
 
         textarea(editorController.current.select { it.textProperty }) {
-            disableWhen(editorController.editMode.not())
+            disableWhen(editorController.editMode.not().or(editorController.current.isNull))
         }
 
         text("Keywords")

--- a/src/main/kotlin/view/MenuView.kt
+++ b/src/main/kotlin/view/MenuView.kt
@@ -1,6 +1,7 @@
 package main.kotlin.view
 
 import javafx.stage.FileChooser
+import main.kotlin.controller.AppdirController
 import main.kotlin.controller.StoreController
 import tornadofx.*
 

--- a/src/main/kotlin/view/MenuView.kt
+++ b/src/main/kotlin/view/MenuView.kt
@@ -33,14 +33,15 @@ class MenuView : View() {
                 items.bind(appdirController.files.select { it.recentFiles }.value) { path ->
                     val menuItem = MenuItem(path.toString())
                     menuItem.action {
-                        if (storeController.location.isNull.get() ||
-                            storeController.location.isNotNull.get() && path != storeController.location.get().toPath()
+                        if (!path.toFile().exists()) {
+                            warning("Unknown file", "File no longer exists, and will be removed")
+                            appdirController.files.value.recentFiles.remove(path)
+                        } else if (storeController.location.isNull.get()
+                            || storeController.location.isNotNull.get() && path != storeController.location.get()
+                                .toPath()
+                            && savePrompt(storeController, currentStage?.owner)
                         ) {
-                            if (savePrompt(
-                                    storeController,
-                                    currentStage?.owner
-                                )
-                            ) storeController.loadJournal(path.toFile())
+                            storeController.loadJournal(path.toFile())
                         }
                     }
                     menuItem

--- a/src/main/kotlin/view/MenuView.kt
+++ b/src/main/kotlin/view/MenuView.kt
@@ -1,16 +1,20 @@
 package main.kotlin.view
 
+import javafx.scene.control.MenuItem
 import javafx.stage.FileChooser
+import main.kotlin.JournalApp.Companion.savePrompt
 import main.kotlin.controller.AppdirController
 import main.kotlin.controller.StoreController
 import tornadofx.*
 
 class MenuView : View() {
+    val appdirController: AppdirController by inject()
     val storeController: StoreController by inject()
+
     val filters = arrayOf(FileChooser.ExtensionFilter("Journal Entry", "*.journal"))
 
-    fun save(prompt: Boolean = false) {
-        if (prompt || storeController.location.isNull.get()) {
+    fun save(saveAs: Boolean = false) {
+        if (saveAs || storeController.location.isNull.get()) {
             val files = chooseFile(title = "Save As", mode = FileChooserMode.Save, filters = filters)
             if (files.isNotEmpty()) storeController.saveJournal(files[0])
         } else storeController.saveJournal()
@@ -19,8 +23,28 @@ class MenuView : View() {
     override val root = menubar {
         menu("File") {
             item("Open").action {
-                val files = chooseFile(title = "Open", mode = FileChooserMode.Single, filters = filters)
-                if (files.isNotEmpty()) storeController.loadJournal(files[0])
+                if (savePrompt(storeController, currentStage?.owner)) {
+                    val files = chooseFile(title = "Open", mode = FileChooserMode.Single, filters = filters)
+                    if (files.isNotEmpty()) storeController.loadJournal(files[0])
+                }
+            }
+            menu("Open Recent") {
+                disableWhen(appdirController.files.isNull)
+                items.bind(appdirController.files.select { it.recentFiles }.value) { path ->
+                    val menuItem = MenuItem(path.toString())
+                    menuItem.action {
+                        if (storeController.location.isNull.get() ||
+                            storeController.location.isNotNull.get() && path != storeController.location.get().toPath()
+                        ) {
+                            if (savePrompt(
+                                    storeController,
+                                    currentStage?.owner
+                                )
+                            ) storeController.loadJournal(path.toFile())
+                        }
+                    }
+                    menuItem
+                }
             }
             separator()
             item("Save") {


### PR DESCRIPTION
Create an appdata folder on first boot, which can be used to store non-volatile data.

For now, this makes it easy to store the most recent files that we have opened.
We all have an "Open Recent" menu option which:
- Shows up to 10 of the most recent journals we have opened
- Shows a prompt if we wish to switch between a file while having unsaved changes
- This same prompt is used when we want to open an existing journal with unsaved changes (or close the application)

Todo:
- [x] Elegant error handling so that if a journal was deleted which is in the recent items list, the user gets a prompt telling them so, after which this item is then deleted from the recent items list. 