### PR TITLE
Allow adding of reference and show position in text area

### DIFF
--- a/src/main/kotlin/JournalApp.kt
+++ b/src/main/kotlin/JournalApp.kt
@@ -76,7 +76,8 @@ class JournalApp : App(MainView::class, Styles::class) {
 
         stage.setOnCloseRequest {
             if (storeController.journal.isNotNull.get() && storeController.journal.selectBoolean { it.editedProperty }.value) {
-                savePrompt(storeController, stage.owner)
+                val savePrompt = savePrompt(storeController, stage.owner)
+                if (!savePrompt) it.consume()
             }
             appdirController.writeToFile()
         }

--- a/src/main/kotlin/JournalApp.kt
+++ b/src/main/kotlin/JournalApp.kt
@@ -1,6 +1,7 @@
 package main.kotlin
 
 import javafx.application.Application
+import javafx.application.Platform
 import javafx.beans.binding.Bindings
 import javafx.scene.control.ButtonType
 import javafx.scene.control.ButtonType.*
@@ -56,12 +57,14 @@ class JournalApp : App(MainView::class, Styles::class) {
         val userConfigDir = appDirs.getUserConfigDir(CREDENTIALS_APP_NAME, CREDENTIALS_VERSION, CREDENTIALS_AUTHOR)
         appdirController.appdir.set(File(userConfigDir))
 
-        try {
-            referencesController.connect()
-            referencesController.refreshReferences()
-        } catch (e: Exception) {
-            // TODO use logger
-            e.printStackTrace()
+        Platform.runLater {
+            try {
+                referencesController.connect()
+                referencesController.refreshReferences()
+            } catch (e: Exception) {
+                // TODO use logger
+                e.printStackTrace()
+            }
         }
 
         super.start(stage)

--- a/src/main/kotlin/Styles.kt
+++ b/src/main/kotlin/Styles.kt
@@ -17,6 +17,9 @@ class Styles : Stylesheet() {
         val buttons by cssclass()
 
         val highlightColor = Color.YELLOW
+        val hoverBackground = "black"
+        val hoverTextColor = "white"
+        val hoverPaddingPx = 3
     }
 
     init {

--- a/src/main/kotlin/Styles.kt
+++ b/src/main/kotlin/Styles.kt
@@ -15,6 +15,8 @@ class Styles : Stylesheet() {
         val customContainer by cssclass()
         val nestedContainer by cssclass()
         val buttons by cssclass()
+
+        val highlightColor = Color.YELLOW
     }
 
     init {

--- a/src/main/kotlin/controller/AppdirController.kt
+++ b/src/main/kotlin/controller/AppdirController.kt
@@ -1,6 +1,5 @@
 package main.kotlin.controller
 
-import com.moandjiezana.toml.Toml
 import com.moandjiezana.toml.TomlWriter
 import javafx.beans.property.SimpleObjectProperty
 import main.kotlin.model.appdir.Files

--- a/src/main/kotlin/controller/EditorController.kt
+++ b/src/main/kotlin/controller/EditorController.kt
@@ -1,6 +1,7 @@
 package main.kotlin.controller
 
 import javafx.beans.property.SimpleBooleanProperty
+import javafx.beans.property.SimpleIntegerProperty
 import javafx.beans.property.SimpleListProperty
 import javafx.beans.property.SimpleObjectProperty
 import javafx.scene.control.IndexRange
@@ -11,11 +12,13 @@ import tornadofx.asObservable
 
 class EditorController : Controller() {
     val current = SimpleObjectProperty<JournalEntry>()
-    val editMode = SimpleBooleanProperty()
-    val editable = current.isNotNull.and(editMode)
+    val isEditMode = SimpleBooleanProperty()
+    val isEditable = current.isNotNull.and(isEditMode)
 
     val selectionBounds = SimpleObjectProperty<IndexRange>()
-    val validSelection = current.isNotNull.and(selectionBounds.isNotNull)
+    val isValidSelection = current.isNotNull.and(selectionBounds.isNotNull)
 
+    val rowPosition = SimpleIntegerProperty()
+    val colPosition = SimpleIntegerProperty()
     val hoveredReferencePosition = SimpleListProperty(mutableListOf<ReferencePosition>().asObservable())
 }

--- a/src/main/kotlin/controller/EditorController.kt
+++ b/src/main/kotlin/controller/EditorController.kt
@@ -8,6 +8,7 @@ import tornadofx.Controller
 
 class EditorController : Controller() {
     val current = SimpleObjectProperty<JournalEntry>()
+
     val caretPosition = SimpleIntegerProperty()
 
     val editMode = SimpleBooleanProperty()

--- a/src/main/kotlin/controller/EditorController.kt
+++ b/src/main/kotlin/controller/EditorController.kt
@@ -1,15 +1,15 @@
 package main.kotlin.controller
 
 import javafx.beans.property.SimpleBooleanProperty
-import javafx.beans.property.SimpleIntegerProperty
 import javafx.beans.property.SimpleObjectProperty
+import javafx.scene.control.IndexRange
 import main.kotlin.model.JournalEntry
 import tornadofx.Controller
 
 class EditorController : Controller() {
     val current = SimpleObjectProperty<JournalEntry>()
 
-    val caretPosition = SimpleIntegerProperty()
+    val selectionBounds = SimpleObjectProperty<IndexRange>()
 
     val editMode = SimpleBooleanProperty()
 }

--- a/src/main/kotlin/controller/EditorController.kt
+++ b/src/main/kotlin/controller/EditorController.kt
@@ -11,11 +11,11 @@ import tornadofx.asObservable
 
 class EditorController : Controller() {
     val current = SimpleObjectProperty<JournalEntry>()
+    val editMode = SimpleBooleanProperty()
+    val editable = current.isNotNull.and(editMode)
 
     val selectionBounds = SimpleObjectProperty<IndexRange>()
     val validSelection = current.isNotNull.and(selectionBounds.isNotNull)
 
     val hoveredReferencePosition = SimpleListProperty(mutableListOf<ReferencePosition>().asObservable())
-
-    val editMode = SimpleBooleanProperty()
 }

--- a/src/main/kotlin/controller/EditorController.kt
+++ b/src/main/kotlin/controller/EditorController.kt
@@ -1,15 +1,21 @@
 package main.kotlin.controller
 
 import javafx.beans.property.SimpleBooleanProperty
+import javafx.beans.property.SimpleListProperty
 import javafx.beans.property.SimpleObjectProperty
 import javafx.scene.control.IndexRange
 import main.kotlin.model.JournalEntry
+import main.kotlin.model.ReferencePosition
 import tornadofx.Controller
+import tornadofx.asObservable
 
 class EditorController : Controller() {
     val current = SimpleObjectProperty<JournalEntry>()
 
     val selectionBounds = SimpleObjectProperty<IndexRange>()
+    val validSelection = current.isNotNull.and(selectionBounds.isNotNull)
+
+    val hoveredReferencePosition = SimpleListProperty(mutableListOf<ReferencePosition>().asObservable())
 
     val editMode = SimpleBooleanProperty()
 }

--- a/src/main/kotlin/controller/EditorController.kt
+++ b/src/main/kotlin/controller/EditorController.kt
@@ -1,12 +1,14 @@
 package main.kotlin.controller
 
 import javafx.beans.property.SimpleBooleanProperty
+import javafx.beans.property.SimpleIntegerProperty
 import javafx.beans.property.SimpleObjectProperty
 import main.kotlin.model.JournalEntry
 import tornadofx.Controller
 
 class EditorController : Controller() {
     val current = SimpleObjectProperty<JournalEntry>()
+    val caretPosition = SimpleIntegerProperty()
 
     val editMode = SimpleBooleanProperty()
 }

--- a/src/main/kotlin/controller/ReferencesController.kt
+++ b/src/main/kotlin/controller/ReferencesController.kt
@@ -23,6 +23,7 @@ class ReferencesController : Controller() {
     private val fieldTypes = mutableMapOf<String, Int>()
     val authorMapping = SimpleMapProperty<Int, Author>()
     val referenceMapping = SimpleMapProperty<Int, Reference>()
+    val selectedReference = SimpleObjectProperty<Reference>()
 
     init {
         referenceMapping.onChange {

--- a/src/main/kotlin/model/JournalEntry.kt
+++ b/src/main/kotlin/model/JournalEntry.kt
@@ -59,9 +59,15 @@ class JournalEntry(
         keywordsProperty.forEach { keyword -> keyword.editedProperty.onChange { editedProperty.set(editedProperty.get() || it) } }
     }
 
+    /**
+     * Sets edit status to false if true, else does nothing.
+     */
     fun reset() {
+        if (!editedProperty.get()) return
+
         keywordsProperty.forEach { it.editedProperty.set(false) }
         editedProperty.set(false)
+        lastEditProperty.set(LocalDateTime.now())
     }
 
     override fun equals(other: Any?): Boolean = other is JournalEntry

--- a/src/main/kotlin/model/ReferencePosition.kt
+++ b/src/main/kotlin/model/ReferencePosition.kt
@@ -76,7 +76,7 @@ object ReferencePositionSerializer : KSerializer<ReferencePosition> {
 
 class NoteModel(property: ObjectProperty<ReferencePosition>) :
     ItemViewModel<ReferencePosition>(itemProperty = property) {
-    val start = bind(autocommit = true) { property.select { it.startProperty } }
-    val end = bind(autocommit = true) { property.select { it.endProperty } }
+    val start = bind(autocommit = true) { property.select { it.startProperty.asString() } }
+    val end = bind(autocommit = true) { property.select { it.endProperty.asString() } }
     val reference: ObjectProperty<Reference> = bind(autocommit = true) { property.select { it.referenceProperty } }
 }

--- a/src/main/kotlin/model/ReferencePosition.kt
+++ b/src/main/kotlin/model/ReferencePosition.kt
@@ -1,6 +1,5 @@
 package main.kotlin.model
 
-import javafx.beans.property.IntegerProperty
 import javafx.beans.property.ObjectProperty
 import javafx.beans.property.SimpleIntegerProperty
 import javafx.beans.property.SimpleObjectProperty
@@ -18,24 +17,27 @@ import tornadofx.select
 class ReferencePosition(val referenceId: Int, start: Int, end: Int) {
     val startProperty = SimpleIntegerProperty(start)
     val endProperty = SimpleIntegerProperty(end)
-    val reference = SimpleObjectProperty<Reference>()
+    val referenceProperty = SimpleObjectProperty<Reference>()
+
+    /**
+     * Set reference directly.
+     *
+     * Useful if all references have already been loaded.
+     */
+    constructor(reference: Reference, start: Int, end: Int) : this(reference.id, start, end) {
+        referenceProperty.set(reference)
+    }
 
     /**
      * Load reference based on mapping from identifier to actual reference.
      */
-    fun loadReference(referenceMapping: Map<Int, Reference>) {
-        reference.set(referenceMapping[referenceId])
-    }
+    fun loadReference(referenceMapping: Map<Int, Reference>) = referenceProperty.set(referenceMapping[referenceId])
 
-    override fun equals(other: Any?): Boolean =
-        other is ReferencePosition && startProperty.get() == other.startProperty.get()
-                && endProperty.get() == other.endProperty.get() && referenceId == other.referenceId
+    override fun equals(other: Any?): Boolean = other is ReferencePosition
+            && startProperty.get() == other.startProperty.get()
+            && endProperty.get() == other.endProperty.get() && referenceId == other.referenceId
 
-    override fun hashCode(): Int {
-        var result = startProperty.hashCode()
-        result = 31 * result + endProperty.hashCode()
-        return 31 * result + referenceId
-    }
+    override fun hashCode(): Int = 31 * (31 * startProperty.hashCode() + endProperty.hashCode()) + referenceId
 }
 
 /**
@@ -74,6 +76,7 @@ object ReferencePositionSerializer : KSerializer<ReferencePosition> {
 
 class NoteModel(property: ObjectProperty<ReferencePosition>) :
     ItemViewModel<ReferencePosition>(itemProperty = property) {
-    val start: IntegerProperty = bind(autocommit = true) { property.select { it.startProperty } }
-    val end: IntegerProperty = bind(autocommit = true) { property.select { it.endProperty } }
+    val start = bind(autocommit = true) { property.select { it.startProperty } }
+    val end = bind(autocommit = true) { property.select { it.endProperty } }
+    val reference: ObjectProperty<Reference> = bind(autocommit = true) { property.select { it.referenceProperty } }
 }

--- a/src/main/kotlin/view/fragment/KeywordFragment.kt
+++ b/src/main/kotlin/view/fragment/KeywordFragment.kt
@@ -23,7 +23,7 @@ class KeywordFragment : ListCellFragment<Keyword>() {
         }
 
         textfield(entry.value) {
-            disableWhen(editorController.editMode.not())
+            disableWhen(editorController.isEditMode.not())
         }
     }
 }

--- a/src/main/kotlin/view/main/EditorView.kt
+++ b/src/main/kotlin/view/main/EditorView.kt
@@ -56,7 +56,7 @@ class EditorView : View() {
                     }
                 }
             }
-            editorController.caretPosition.bind(area.caretPositionProperty())
+            editorController.selectionBounds.bind(area.selectionProperty())
 
             area.addEventHandler(MouseOverTextEvent.MOUSE_OVER_TEXT_END) { popup.hide() }
             // binding does not work, so manually update each time instead

--- a/src/main/kotlin/view/main/EditorView.kt
+++ b/src/main/kotlin/view/main/EditorView.kt
@@ -41,10 +41,20 @@ class EditorView : View() {
 
             area.mouseOverTextDelay = Duration.ofMillis(100)
             area.addEventHandler(MouseOverTextEvent.MOUSE_OVER_TEXT_BEGIN) {
-                val chIdx = it.characterIndex
-                val pos = it.screenPosition
-                popupMsg.text = "Character '" + area.getText(chIdx, chIdx + 1) + "' at " + pos
-                popup.show(area, pos.x, pos.y + 10)
+                if (editorController.current.isNotNull.get()) {
+                    val chIdx = it.characterIndex
+                    for (referencePosition in editorController.current.get().referencesProperty) {
+                        if (referencePosition.startProperty <= chIdx && referencePosition.endProperty >= chIdx
+                            && referencePosition.referenceProperty.isNotNull.get()
+                        ) {
+                            popupMsg.text = referencePosition.referenceProperty.get().title
+
+                            val pos = it.screenPosition
+                            popup.show(area, pos.x, pos.y + 10)
+                            break
+                        }
+                    }
+                }
             }
             editorController.caretPosition.bind(area.caretPositionProperty())
 

--- a/src/main/kotlin/view/main/EditorView.kt
+++ b/src/main/kotlin/view/main/EditorView.kt
@@ -43,17 +43,29 @@ class EditorView : View() {
             area.addEventHandler(MouseOverTextEvent.MOUSE_OVER_TEXT_BEGIN) {
                 if (editorController.current.isNotNull.get()) {
                     val chIdx = it.characterIndex
+                    val pos = it.screenPosition
+                    val items = mutableListOf<Pair<Pair<Int, Int>, String>>()
+
                     for (referencePosition in editorController.current.get().referencesProperty) {
                         if (referencePosition.startProperty <= chIdx && referencePosition.endProperty >= chIdx
                             && referencePosition.referenceProperty.isNotNull.get()
                         ) {
-                            popupMsg.text = referencePosition.referenceProperty.get().title
-
-                            val pos = it.screenPosition
-                            popup.show(area, pos.x, pos.y + 10)
-                            break
+                            items += Pair(
+                                Pair(referencePosition.startProperty.get(), referencePosition.endProperty.get()),
+                                referencePosition.referenceProperty.get().title
+                            )
                         }
                     }
+
+                    if (items.isEmpty()) return@addEventHandler
+                    if (items.size > 1) {
+                        val stringBuilder = StringBuilder()
+                        items.forEach { i -> stringBuilder.append("${i.first.first} - ${i.first.second}: ${i.second}\n") }
+                        popupMsg.text = stringBuilder.toString()
+                    } else {
+                        popupMsg.text = "${items[0].first.first} - ${items[0].first.second}: ${items[0].second}\n"
+                    }
+                    popup.show(area, pos.x, pos.y + 10)
                 }
             }
             editorController.selectionBounds.bind(area.selectionProperty())

--- a/src/main/kotlin/view/main/EditorView.kt
+++ b/src/main/kotlin/view/main/EditorView.kt
@@ -39,7 +39,7 @@ class EditorView : View() {
 
         textfield(editorController.current.select { it.titleProperty }) {
             promptText = "Title"
-            disableWhen(editorController.editable.not())
+            disableWhen(editorController.isEditable.not())
         }
 
         run {
@@ -136,10 +136,19 @@ class EditorView : View() {
             area.vgrow = Priority.ALWAYS
             area.isWrapText = true
 
+            editorController.rowPosition.bind(area.currentParagraphProperty())
+            editorController.colPosition.bind(area.caretColumnProperty())
+
             // does not work nicely with TornadoFX, so add manually
             popup.content.add(popupMsg)
             children.add(area)
-            area.disableWhen(editorController.editable.not())
+            area.disableWhen(editorController.isEditable.not())
+        }
+
+        hbox {
+            text(editorController.rowPosition.asString())
+            text(":")
+            text(editorController.colPosition.asString())
         }
 
         hbox {
@@ -152,7 +161,7 @@ class EditorView : View() {
         hbox {
             addClass(Styles.buttons)
             button("+") {
-                disableWhen(editorController.validSelection.not().or(editorController.editable.not()))
+                disableWhen(editorController.isValidSelection.not().or(editorController.isEditable.not()))
                 action { editorController.current.get().keywordsProperty.add(Keyword()) }
             }
             listview(editorController.current.select { it.keywordsProperty }) {

--- a/src/main/kotlin/view/main/EntriesView.kt
+++ b/src/main/kotlin/view/main/EntriesView.kt
@@ -1,6 +1,7 @@
 package main.kotlin.view.main
 
 import javafx.scene.control.ButtonType
+import javafx.scene.layout.Priority
 import main.kotlin.Styles
 import main.kotlin.controller.EditorController
 import main.kotlin.controller.StoreController
@@ -22,6 +23,8 @@ class EntriesView : View() {
 
         listview(storeController.journal.select { it.itemsProperty }) {
             cellFragment(EntryFragment::class)
+            vgrow = Priority.ALWAYS
+            hgrow = Priority.NEVER
             bindSelected(editorController.current)
 
             storeController.journal.onChange { _ ->

--- a/src/main/kotlin/view/main/EntriesView.kt
+++ b/src/main/kotlin/view/main/EntriesView.kt
@@ -39,7 +39,7 @@ class EntriesView : View() {
             addClass(Styles.buttons)
             togglebutton("Edit Mode") {
                 disableWhen(storeController.journal.isNull)
-                editorController.editMode.bind(this.selectedProperty())
+                editorController.isEditMode.bind(this.selectedProperty())
             }
             button("save") {
                 disableWhen(storeController.savedProperty)

--- a/src/main/kotlin/view/main/MenuView.kt
+++ b/src/main/kotlin/view/main/MenuView.kt
@@ -9,8 +9,10 @@ import main.kotlin.view.reference.ZoteroView
 import tornadofx.*
 
 class MenuView : View() {
-    val appdirController: AppdirController by inject()
-    val storeController: StoreController by inject()
+    private val appdirController: AppdirController by inject()
+    private val storeController: StoreController by inject()
+
+    val zoteroView: ZoteroView by inject()
 
     val filters = arrayOf(FileChooser.ExtensionFilter("Journal Entry", "*.journal"))
 
@@ -68,7 +70,7 @@ class MenuView : View() {
         }
         menu("References") {
             item("Zotero").action {
-                ZoteroView().openWindow(owner = currentStage, block = true)
+                zoteroView.openWindow(owner = currentStage, block = true)
             }
         }
         menu("Help") {

--- a/src/main/kotlin/view/main/ReferencesView.kt
+++ b/src/main/kotlin/view/main/ReferencesView.kt
@@ -1,7 +1,10 @@
 package main.kotlin.view.main
 
+import javafx.collections.ObservableList
+import javafx.scene.layout.Priority
 import main.kotlin.Styles
 import main.kotlin.controller.EditorController
+import main.kotlin.model.ReferencePosition
 import main.kotlin.view.reference.ReferencePositionFragment
 import main.kotlin.view.reference.ZoteroView
 import tornadofx.*
@@ -16,7 +19,16 @@ class ReferencesView : View() {
 
         text("References") { setId(Styles.title) }
         listview(editorController.current.select { it.referencesProperty }) {
+            vgrow = Priority.ALWAYS
+            hgrow = Priority.NEVER
+            selectionModel
             cellFragment(ReferencePositionFragment::class)
+
+            editorController.hoveredReferencePosition.onChange<ObservableList<ReferencePosition>> {
+                val indices = it?.map { referencePosition -> items.indexOf(referencePosition) } ?: emptyList()
+                selectionModel.clearSelection()
+                if (indices.isNotEmpty()) selectionModel.selectIndices(indices.first(), *indices.toIntArray())
+            }
         }
 
         hbox {

--- a/src/main/kotlin/view/main/ReferencesView.kt
+++ b/src/main/kotlin/view/main/ReferencesView.kt
@@ -22,7 +22,7 @@ class ReferencesView : View() {
         hbox {
             addClass(Styles.buttons)
             button("+") {
-                disableWhen(editorController.current.isNull)
+                disableWhen(editorController.current.isNull.or(editorController.selectionBounds.isNull))
                 action { zoteroView.openWindow(owner = currentStage, block = true) }
             }
         }

--- a/src/main/kotlin/view/main/ReferencesView.kt
+++ b/src/main/kotlin/view/main/ReferencesView.kt
@@ -3,10 +3,13 @@ package main.kotlin.view.main
 import main.kotlin.Styles
 import main.kotlin.controller.EditorController
 import main.kotlin.view.reference.ReferencePositionFragment
+import main.kotlin.view.reference.ZoteroView
 import tornadofx.*
 
 class ReferencesView : View() {
     val editorController: EditorController by inject()
+
+    val zoteroView: ZoteroView by inject()
 
     override val root = vbox {
         addClass(Styles.customContainer)
@@ -19,7 +22,8 @@ class ReferencesView : View() {
         hbox {
             addClass(Styles.buttons)
             button("+") {
-                isVisible = false
+                disableWhen(editorController.current.isNull)
+                action { zoteroView.openWindow(owner = currentStage, block = true) }
             }
         }
     }

--- a/src/main/kotlin/view/reference/ReferenceFragment.kt
+++ b/src/main/kotlin/view/reference/ReferenceFragment.kt
@@ -4,11 +4,14 @@ import javafx.beans.binding.Bindings
 import javafx.beans.property.Property
 import javafx.beans.property.SimpleBooleanProperty
 import javafx.beans.property.SimpleObjectProperty
+import main.kotlin.controller.ReferencesController
 import main.kotlin.model.reference.Reference
 import main.kotlin.model.reference.ReferenceModel
 import tornadofx.*
 
 class ReferenceFragment(item: Property<Reference>? = null) : ListCellFragment<Reference>() {
+    val referenceController: ReferencesController by inject()
+
     val entry = ReferenceModel(item?.let { SimpleObjectProperty(it.value) } ?: itemProperty)
 
     val showAbstract = SimpleBooleanProperty(false)
@@ -21,6 +24,7 @@ class ReferenceFragment(item: Property<Reference>? = null) : ListCellFragment<Re
 
         onLeftClick {
             showAbstract.set(entry.abstract.isNotBlank().get() && !showAbstract.get())
+            referenceController.selectedReference.set(entry.item)
         }
 
         text(entry.title).managedWhen(entry.title.isNotBlank())

--- a/src/main/kotlin/view/reference/ReferencePositionFragment.kt
+++ b/src/main/kotlin/view/reference/ReferencePositionFragment.kt
@@ -2,17 +2,18 @@ package main.kotlin.view.reference
 
 import main.kotlin.model.NoteModel
 import main.kotlin.model.ReferencePosition
-import tornadofx.ListCellFragment
-import tornadofx.select
-import tornadofx.text
-import tornadofx.vbox
+import tornadofx.*
 
 class ReferencePositionFragment : ListCellFragment<ReferencePosition>() {
     val entry = NoteModel(itemProperty)
 
-    val referenceFragment: ReferenceFragment by inject()
-
     override val root = vbox {
+        hbox {
+            text(entry.start)
+            text("-")
+            text(entry.end)
+        }
+
         text(entry.reference.select { it.titleProperty })
     }
 }

--- a/src/main/kotlin/view/reference/ReferencePositionFragment.kt
+++ b/src/main/kotlin/view/reference/ReferencePositionFragment.kt
@@ -2,18 +2,17 @@ package main.kotlin.view.reference
 
 import main.kotlin.model.NoteModel
 import main.kotlin.model.ReferencePosition
-import tornadofx.*
+import tornadofx.ListCellFragment
+import tornadofx.select
+import tornadofx.text
+import tornadofx.vbox
 
 class ReferencePositionFragment : ListCellFragment<ReferencePosition>() {
     val entry = NoteModel(itemProperty)
 
-    override val root = vbox {
-        hbox {
-            text(entry.start.asString())
-            text("-")
-            text(entry.end.asString())
-        }
+    val referenceFragment: ReferenceFragment by inject()
 
-        ReferenceFragment(itemProperty.select { it.reference }).root
+    override val root = vbox {
+        text(entry.reference.select { it.titleProperty })
     }
 }

--- a/src/main/kotlin/view/reference/ZoteroView.kt
+++ b/src/main/kotlin/view/reference/ZoteroView.kt
@@ -1,11 +1,14 @@
 package main.kotlin.view.reference
 
 import main.kotlin.Styles
+import main.kotlin.controller.EditorController
 import main.kotlin.controller.ReferencesController
+import main.kotlin.model.ReferencePosition
 import tornadofx.*
 
 class ZoteroView : View() {
     val referencesController: ReferencesController by inject()
+    val editorController: EditorController by inject()
 
     override val root = gridpane {
         addClass(Styles.customContainer)
@@ -45,6 +48,22 @@ class ZoteroView : View() {
                 text("Items") { setId(Styles.title) }
                 listview(observableListOf(referencesController.referenceMapping.values)) {
                     cellFragment(ReferenceFragment::class)
+                }
+            }
+        }
+
+        row {
+            button("+") {
+                disableWhen(editorController.current.isNull.or(referencesController.selectedReference.isNull))
+                action {
+                    editorController.current.get().referencesProperty.add(
+                        ReferencePosition(
+                            start = editorController.caretPosition.get(),
+                            end = editorController.caretPosition.get(),
+                            reference = referencesController.selectedReference.get()
+                        )
+                    )
+                    currentStage?.close()
                 }
             }
         }

--- a/src/main/kotlin/view/reference/ZoteroView.kt
+++ b/src/main/kotlin/view/reference/ZoteroView.kt
@@ -54,12 +54,12 @@ class ZoteroView : View() {
 
         row {
             button("+") {
-                disableWhen(editorController.current.isNull.or(referencesController.selectedReference.isNull))
+                disableWhen(editorController.selectionBounds.isNull.or(referencesController.selectedReference.isNull))
                 action {
                     editorController.current.get().referencesProperty.add(
                         ReferencePosition(
-                            start = editorController.caretPosition.get(),
-                            end = editorController.caretPosition.get(),
+                            start = editorController.selectionBounds.get().start,
+                            end = editorController.selectionBounds.get().end,
                             reference = referencesController.selectedReference.get()
                         )
                     )

--- a/src/main/kotlin/view/reference/ZoteroView.kt
+++ b/src/main/kotlin/view/reference/ZoteroView.kt
@@ -55,11 +55,9 @@ class ZoteroView : View() {
         row {
             button("+") {
                 disableWhen(
-                    editorController.current.isNull.or(
-                        editorController.selectionBounds.isNull.or(
-                            referencesController.selectedReference.isNull
-                        )
-                    )
+                    editorController.validSelection.not()
+                        .or(editorController.editMode.not())
+                        .or(referencesController.selectedReference.isNull)
                 )
                 action {
                     editorController.current.get().referencesProperty.add(

--- a/src/main/kotlin/view/reference/ZoteroView.kt
+++ b/src/main/kotlin/view/reference/ZoteroView.kt
@@ -55,8 +55,8 @@ class ZoteroView : View() {
         row {
             button("+") {
                 disableWhen(
-                    editorController.validSelection.not()
-                        .or(editorController.editMode.not())
+                    editorController.isValidSelection.not()
+                        .or(editorController.isEditMode.not())
                         .or(referencesController.selectedReference.isNull)
                 )
                 action {

--- a/src/main/kotlin/view/reference/ZoteroView.kt
+++ b/src/main/kotlin/view/reference/ZoteroView.kt
@@ -54,7 +54,13 @@ class ZoteroView : View() {
 
         row {
             button("+") {
-                disableWhen(editorController.selectionBounds.isNull.or(referencesController.selectedReference.isNull))
+                disableWhen(
+                    editorController.current.isNull.or(
+                        editorController.selectionBounds.isNull.or(
+                            referencesController.selectedReference.isNull
+                        )
+                    )
+                )
                 action {
                     editorController.current.get().referencesProperty.add(
                         ReferencePosition(


### PR DESCRIPTION
Use RichTextFX text area for more advanced features, including highlighting of references.
A few features:
- On hover, we can see what was referenced where (both as a tooltip and highlighted in the overview)
- We can add references
- References are removed if the text is removed

A few things:
- Text positions of references are not updated if we add new text
- We cannot remove references without deleting all text starting at its starting position

### TODO
- [x] implements #10 
- [x] implements #5 
- [x] Allow adding of new citations, using the global citation view