### PR TITLE
Update referencepositions if selection moved in text

### DIFF
--- a/src/main/kotlin/view/main/EditorView.kt
+++ b/src/main/kotlin/view/main/EditorView.kt
@@ -113,9 +113,10 @@ class EditorView : View() {
                         path.fill = Styles.highlightColor
                     }
 
-                    selections.add(selectionImpl)
-                    area.addSelection(selectionImpl)
                     if (area.text.length >= referencePosition.endProperty.get()) {
+                        selections.add(selectionImpl)
+                        area.addSelection(selectionImpl)
+
                         selectionImpl.selectRange(
                             referencePosition.startProperty.get(),
                             referencePosition.endProperty.get()

--- a/src/main/kotlin/view/main/EditorView.kt
+++ b/src/main/kotlin/view/main/EditorView.kt
@@ -115,10 +115,14 @@ class EditorView : View() {
 
                     selections.add(selectionImpl)
                     area.addSelection(selectionImpl)
-                    if (area.text.length >= referencePosition.endProperty.get()) selectionImpl.selectRange(
-                        referencePosition.startProperty.get(),
-                        referencePosition.endProperty.get()
-                    )
+                    if (area.text.length >= referencePosition.endProperty.get()) {
+                        selectionImpl.selectRange(
+                            referencePosition.startProperty.get(),
+                            referencePosition.endProperty.get()
+                        )
+                        referencePosition.startProperty.bind(selectionImpl.startPositionProperty())
+                        referencePosition.endProperty.bind(selectionImpl.endPositionProperty())
+                    }
                 }
 
                 journalEntry?.referencesProperty?.forEach(setStyle)


### PR DESCRIPTION
The text area already implements logic for moving highlights, so we can just bind our own properties to its location.
Removing the highlight causes no errors, the reference then just disappears as was previous behavior.

Fixes #26 