### PR TITLE
Show reference in reference view if double clicked in list next to editor view

### DIFF
--- a/src/main/kotlin/view/main/ReferencesView.kt
+++ b/src/main/kotlin/view/main/ReferencesView.kt
@@ -21,7 +21,6 @@ class ReferencesView : View() {
         listview(editorController.current.select { it.referencesProperty }) {
             vgrow = Priority.ALWAYS
             hgrow = Priority.NEVER
-            selectionModel
             cellFragment(ReferencePositionFragment::class)
 
             editorController.hoveredReferencePosition.onChange<ObservableList<ReferencePosition>> {

--- a/src/main/kotlin/view/main/ReferencesView.kt
+++ b/src/main/kotlin/view/main/ReferencesView.kt
@@ -10,9 +10,9 @@ import main.kotlin.view.reference.ZoteroView
 import tornadofx.*
 
 class ReferencesView : View() {
-    val editorController: EditorController by inject()
+    private val editorController: EditorController by inject()
 
-    val zoteroView: ZoteroView by inject()
+    private val zoteroView: ZoteroView by inject()
 
     override val root = vbox {
         addClass(Styles.customContainer)

--- a/src/main/kotlin/view/reference/ReferencePositionFragment.kt
+++ b/src/main/kotlin/view/reference/ReferencePositionFragment.kt
@@ -1,11 +1,15 @@
 package main.kotlin.view.reference
 
+import main.kotlin.controller.ReferencesController
 import main.kotlin.model.NoteModel
 import main.kotlin.model.ReferencePosition
 import tornadofx.*
 
 class ReferencePositionFragment : ListCellFragment<ReferencePosition>() {
     val entry = NoteModel(itemProperty)
+
+    val referencesController: ReferencesController by inject()
+    val referencesView: ZoteroView by inject()
 
     override val root = vbox {
         hbox {
@@ -15,5 +19,12 @@ class ReferencePositionFragment : ListCellFragment<ReferencePosition>() {
         }
 
         text(entry.reference.select { it.titleProperty })
+
+        setOnMouseClicked {
+            if (it.clickCount == 2 && entry.reference.isNotNull.get()) {
+                referencesController.selectedReference.set(entry.reference.value)
+                referencesView.openWindow(owner = currentWindow, block = true)
+            }
+        }
     }
 }

--- a/src/main/kotlin/view/reference/ZoteroView.kt
+++ b/src/main/kotlin/view/reference/ZoteroView.kt
@@ -48,8 +48,10 @@ class ZoteroView : View() {
                 text("Items") { setId(Styles.title) }
                 listview(observableListOf(referencesController.referenceMapping.values)) {
                     cellFragment(ReferenceFragment::class)
+
                     referencesController.selectedReference.onChange {
                         selectionModel.select(it)
+                        scrollTo(selectionModel.selectedIndex)
                         focusModel.focus(selectionModel.selectedIndex)
                         requestFocus()
                     }

--- a/src/main/kotlin/view/reference/ZoteroView.kt
+++ b/src/main/kotlin/view/reference/ZoteroView.kt
@@ -48,6 +48,11 @@ class ZoteroView : View() {
                 text("Items") { setId(Styles.title) }
                 listview(observableListOf(referencesController.referenceMapping.values)) {
                     cellFragment(ReferenceFragment::class)
+                    referencesController.selectedReference.onChange {
+                        selectionModel.select(it)
+                        focusModel.focus(selectionModel.selectedIndex)
+                        requestFocus()
+                    }
                 }
             }
         }


### PR DESCRIPTION
When double clicking on a reference in the reference list in the editor view, we open the Zotero window and we scroll and select the backing reference.

Implements #32 