### PR TITLE
Don't overwrite text when switching between Journal entries

### DIFF
--- a/src/main/kotlin/model/JournalEntry.kt
+++ b/src/main/kotlin/model/JournalEntry.kt
@@ -168,9 +168,7 @@ object JournalEntrySerializer : KSerializer<JournalEntry> {
 class JournalEntryModel(property: ObjectProperty<JournalEntry>) :
     ItemViewModel<JournalEntry>(itemProperty = property) {
     val title = bind(autocommit = true) { property.select { it.titleProperty } }
-    val text = bind(autocommit = true) { property.select { it.textProperty } }
     val edited = bind(autocommit = true) { property.select { it.editedProperty } }
-    val lastEdit = bind(autocommit = true) { property.select { it.lastEditProperty } }
     val creation = bind(autocommit = true) { property.select { it.creationProperty } }
     val tags: ObservableList<Tag> = bind(autocommit = true) { property.select { it.tagList } }
 }


### PR DESCRIPTION
Before, we deleted text on swtiching.
Now we have simplified the logic, and simply unbind the text property of the entry we are switching from so its properties remain untouched.