### PR TITLE
Open most recent journal item on boot

### DIFF
--- a/src/main/kotlin/JournalApp.kt
+++ b/src/main/kotlin/JournalApp.kt
@@ -71,7 +71,8 @@ class JournalApp : App(MainView::class, Styles::class) {
         stage.titleProperty().bind(
             Bindings.concat(
                 journalController.journalProperty.select { it.titleProperty },
-                Bindings.`when`(journalController.savedProperty).then("").otherwise(" [Unsaved]")
+                Bindings.`when`(journalController.journalProperty.selectBoolean { it.editedProperty })
+                    .then(" [Unsaved]").otherwise("")
             )
         )
 

--- a/src/main/kotlin/controller/EditorController.kt
+++ b/src/main/kotlin/controller/EditorController.kt
@@ -10,8 +10,11 @@ import main.kotlin.model.ReferencePosition
 import main.kotlin.model.Tag
 import tornadofx.Controller
 import tornadofx.asObservable
+import tornadofx.onChange
 
 class EditorController : Controller() {
+    val journalController: JournalController by inject()
+
     val current = SimpleObjectProperty<JournalEntry>()
     val isEditMode = SimpleBooleanProperty()
     val isEditable = current.isNotNull.and(isEditMode)
@@ -24,4 +27,10 @@ class EditorController : Controller() {
     val hoveredReferencePosition = SimpleListProperty(mutableListOf<ReferencePosition>().asObservable())
 
     val selectedKeywordProperty = SimpleObjectProperty<Tag>()
+
+    init {
+        journalController.journalProperty.onChange {
+            if (it != null && it.entriesProperty.isNotEmpty()) current.set(it.entriesProperty.last())
+        }
+    }
 }

--- a/src/main/kotlin/controller/EditorController.kt
+++ b/src/main/kotlin/controller/EditorController.kt
@@ -13,7 +13,7 @@ import tornadofx.asObservable
 import tornadofx.onChange
 
 class EditorController : Controller() {
-    val journalController: JournalController by inject()
+    private val journalController: JournalController by inject()
 
     val current = SimpleObjectProperty<JournalEntry>()
     val isEditMode = SimpleBooleanProperty()
@@ -29,6 +29,11 @@ class EditorController : Controller() {
     val selectedKeywordProperty = SimpleObjectProperty<Tag>()
 
     init {
+        // Set as this controller is initialized after journal is loaded
+        if (journalController.journalProperty.isNotNull.get() && journalController.journalProperty.value.entriesProperty.isNotEmpty()) {
+            current.set(journalController.journalProperty.value.entriesProperty.last())
+        }
+
         journalController.journalProperty.onChange {
             if (it != null && it.entriesProperty.isNotEmpty()) current.set(it.entriesProperty.last())
         }

--- a/src/main/kotlin/controller/JournalController.kt
+++ b/src/main/kotlin/controller/JournalController.kt
@@ -1,14 +1,11 @@
 package main.kotlin.controller
 
-import javafx.beans.property.SimpleBooleanProperty
 import javafx.beans.property.SimpleObjectProperty
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import main.kotlin.model.JournalEntry
 import main.kotlin.model.journal.Journal
 import tornadofx.Controller
-import tornadofx.cleanBind
-import tornadofx.select
 import java.io.File
 import java.time.LocalDateTime
 import java.time.ZoneOffset
@@ -17,7 +14,6 @@ class JournalController : Controller() {
     val appdirController: AppdirController by inject()
 
     val location = SimpleObjectProperty<File>()
-    val savedProperty = SimpleBooleanProperty(false)
 
     val journalProperty = SimpleObjectProperty(Journal())
 
@@ -35,7 +31,6 @@ class JournalController : Controller() {
         journalProperty.set(journal)
         location.set(file)
         appdirController.loadedJournal(journal, file)
-        savedProperty.cleanBind(journalProperty.select { it.editedProperty.not() })
     }
 
     fun saveJournal() = when {

--- a/src/main/kotlin/model/JournalEntry.kt
+++ b/src/main/kotlin/model/JournalEntry.kt
@@ -46,16 +46,22 @@ class JournalEntry(
 
     /**
      * Load reference based on mapping from identifier to actual reference.
+     * Edited property remains unchanged.
      */
     fun loadReference(referenceMapping: Map<Int, Reference>) {
+        val oldEdited = editedProperty.get()
         referencesProperty.forEach { it.loadReference(referenceMapping) }
+        editedProperty.set(oldEdited)
     }
 
     /**
      * Load keywords on boot, populating the keywordsProperty with keywords based on the keyword strings (keys).
+     * Edited property remains unchanged.
      */
     fun loadTags(tagMapping: Map<UUID, Tag>) {
+        val oldEdited = editedProperty.get()
         tagsProperty.addAll(tags.map { tagMapping[it] })
+        editedProperty.set(oldEdited)
     }
 
     init {

--- a/src/main/kotlin/model/journal/Journal.kt
+++ b/src/main/kotlin/model/journal/Journal.kt
@@ -30,7 +30,7 @@ class Journal(title: String = "", items: List<JournalEntry> = listOf(), tags: Se
     val titleProperty = SimpleStringProperty(title)
 
     private val myItems = items.toMutableList().asObservable()
-    val itemsProperty: ReadOnlyListProperty<JournalEntry> = SimpleListProperty(myItems)
+    val entriesProperty: ReadOnlyListProperty<JournalEntry> = SimpleListProperty(myItems)
 
     var editedProperty = SimpleBooleanProperty(false)
 
@@ -49,17 +49,17 @@ class Journal(title: String = "", items: List<JournalEntry> = listOf(), tags: Se
             if (c.wasRemoved()) keywordList.add(c.elementRemoved)
         }
 
-        itemsProperty.forEach { item -> item.loadTags(tags.map { it.id to it }.toMap()) }
+        entriesProperty.forEach { item -> item.loadTags(tags.map { it.id to it }.toMap()) }
         rebindEdited()
     }
 
-    fun reset() = itemsProperty.forEach { it.reset() }
+    fun reset() = entriesProperty.forEach { it.reset() }
 
     /**
      * Load reference based on mapping from identifier to actual reference.
      */
     fun loadReference(referenceMapping: Map<Int, Reference>) {
-        itemsProperty.forEach { it.loadReference(referenceMapping) }
+        entriesProperty.forEach { it.loadReference(referenceMapping) }
     }
 
     fun addKeyword(tag: Tag) {
@@ -85,9 +85,9 @@ class Journal(title: String = "", items: List<JournalEntry> = listOf(), tags: Se
     }
 
     override fun equals(other: Any?): Boolean = other is Journal && titleProperty.get() == other.titleProperty.get()
-            && itemsProperty.toList() == other.itemsProperty.toList()
+            && entriesProperty.toList() == other.entriesProperty.toList()
 
-    override fun hashCode(): Int = 31 * titleProperty.hashCode() + itemsProperty.hashCode()
+    override fun hashCode(): Int = 31 * titleProperty.hashCode() + entriesProperty.hashCode()
 }
 
 /**
@@ -103,7 +103,7 @@ object JournalSerializer : KSerializer<Journal> {
     override fun serialize(encoder: Encoder, value: Journal) = encoder.encodeStructure(descriptor) {
         encodeStringElement(descriptor, 0, value.titleProperty.get())
         encodeSerializableElement(descriptor, 1, SetSerializer((KeywordSerializer)), value.tags.toSet())
-        encodeSerializableElement(descriptor, 2, ListSerializer(JournalEntrySerializer), value.itemsProperty.toList())
+        encodeSerializableElement(descriptor, 2, ListSerializer(JournalEntrySerializer), value.entriesProperty.toList())
     }
 
     override fun deserialize(decoder: Decoder): Journal = decoder.decodeStructure(descriptor) {

--- a/src/main/kotlin/view/keyword/KeywordsView.kt
+++ b/src/main/kotlin/view/keyword/KeywordsView.kt
@@ -29,7 +29,7 @@ class KeywordsView : View() {
         }
 
         button("+") {
-            disableWhen(editorController.isEditMode.not())
+            disableWhen(editorController.isEditable.not())
             action {
                 if (journalController.journalProperty.isNotNull.get()) journalController.journalProperty.value.addKeyword(
                     Tag()

--- a/src/main/kotlin/view/main/EntriesView.kt
+++ b/src/main/kotlin/view/main/EntriesView.kt
@@ -21,7 +21,7 @@ class EntriesView : View() {
 
         text("Entries") { addClass(Styles.title) }
 
-        listview(journalController.journalProperty.select { it.itemsProperty }) {
+        listview(journalController.journalProperty.select { it.entriesProperty }) {
             cellFragment(EntryFragment::class)
             vgrow = Priority.ALWAYS
             hgrow = Priority.NEVER
@@ -48,10 +48,10 @@ class EntriesView : View() {
             button("+").action {
                 var selection = ButtonType.YES
 
-                if (journalController.journalProperty.isNotNull.get() && journalController.journalProperty.get().itemsProperty.isNotEmpty()) {
+                if (journalController.journalProperty.isNotNull.get() && journalController.journalProperty.get().entriesProperty.isNotEmpty()) {
                     val daysAfterEpoch = ChronoUnit.DAYS.between(LocalDate.ofEpochDay(0), LocalDate.now())
 
-                    val lastEntry = journalController.journalProperty.get().itemsProperty.last()
+                    val lastEntry = journalController.journalProperty.get().entriesProperty.last()
                     val lastDate = lastEntry.creationProperty.get()
                     val journalDaysAfterEpoch = ChronoUnit.DAYS.between(LocalDate.ofEpochDay(0), lastDate)
 

--- a/src/main/kotlin/view/main/EntriesView.kt
+++ b/src/main/kotlin/view/main/EntriesView.kt
@@ -39,7 +39,7 @@ class EntriesView : View() {
             addClass(Styles.buttons)
             togglebutton("Edit Mode") {
                 disableWhen(journalController.journalProperty.isNull)
-                editorController.isEditMode.bind(this.selectedProperty())
+                editorController.isEditMode.bindBidirectional(this.selectedProperty())
             }
             button("save") {
                 disableWhen(journalController.journalProperty.select { it.editedProperty.not() })

--- a/src/main/kotlin/view/main/EntriesView.kt
+++ b/src/main/kotlin/view/main/EntriesView.kt
@@ -42,7 +42,7 @@ class EntriesView : View() {
                 editorController.isEditMode.bind(this.selectedProperty())
             }
             button("save") {
-                disableWhen(journalController.savedProperty)
+                disableWhen(journalController.journalProperty.select { it.editedProperty.not() })
                 action { menuViewView.save() }
             }
             button("+").action {

--- a/src/main/kotlin/view/main/EntriesView.kt
+++ b/src/main/kotlin/view/main/EntriesView.kt
@@ -27,12 +27,18 @@ class EntriesView : View() {
             hgrow = Priority.NEVER
             bindSelected(editorController.current)
 
-            journalController.journalProperty.onChange { _ ->
+            val selectLastItem = {
                 if (items.isNotEmpty()) {
-                    scrollTo(items.size - 1)
                     selectionModel.select(items.size - 1)
+                    scrollTo(selectionModel.selectedIndex)
+                    focusModel.focus(selectionModel.selectedIndex)
                 }
             }
+
+            journalController.journalProperty.onChange { selectLastItem.invoke() }
+            // If journal set before attaching listener, still select last item
+            if (journalController.journalProperty.isNotNull.get()) selectLastItem.invoke()
+
         }
 
         hbox {

--- a/src/main/kotlin/view/reference/ReferenceFragment.kt
+++ b/src/main/kotlin/view/reference/ReferenceFragment.kt
@@ -4,6 +4,7 @@ import javafx.beans.binding.Bindings
 import javafx.beans.property.Property
 import javafx.beans.property.SimpleBooleanProperty
 import javafx.beans.property.SimpleObjectProperty
+import javafx.scene.layout.Priority
 import main.kotlin.controller.ReferencesController
 import main.kotlin.model.reference.Reference
 import main.kotlin.model.reference.ReferenceModel
@@ -20,6 +21,7 @@ class ReferenceFragment(item: Property<Reference>? = null) : ListCellFragment<Re
     private val WIDTH = 200.0
 
     override val root = vbox {
+        hgrow = Priority.ALWAYS
         maxWidth = WIDTH
 
         onLeftClick {

--- a/src/main/kotlin/view/reference/ZoteroView.kt
+++ b/src/main/kotlin/view/reference/ZoteroView.kt
@@ -63,7 +63,7 @@ class ZoteroView : View() {
             button("+") {
                 disableWhen(
                     editorController.isValidSelection.not()
-                        .or(editorController.isEditMode.not())
+                        .or(editorController.isEditable.not())
                         .or(referencesController.selectedReference.isNull)
                 )
                 action {

--- a/src/test/kotlin/model/JournalTest.kt
+++ b/src/test/kotlin/model/JournalTest.kt
@@ -19,9 +19,9 @@ class JournalTest : FreeSpec({
             val journal = Json.decodeFromString<Journal>(string)
 
             journal.titleProperty.get() shouldBe "title"
-            journal.itemsProperty.size shouldBe 1
+            journal.entriesProperty.size shouldBe 1
             journal.tags.size shouldBe 1
-            journal.itemsProperty.size shouldBe 1
+            journal.entriesProperty.size shouldBe 1
         }
 
         "can be written to json" {


### PR DESCRIPTION
On boot, when we open a journal, we select the last item and display it.
This item is selected both in the listview, and its contents are shown in the editor view.