### PR TITLE
Change color based on the type of referencing done

### DIFF
--- a/src/main/kotlin/Styles.kt
+++ b/src/main/kotlin/Styles.kt
@@ -29,7 +29,6 @@ class Styles : Stylesheet() {
         val nestedContainer by cssclass()
         val buttons by cssclass()
 
-        val highlightColor = Color.YELLOW
         val hoverBackground = "black"
         val hoverTextColor = "white"
         val hoverPaddingPx = 5
@@ -78,7 +77,7 @@ class Styles : Stylesheet() {
         }
 
         entryItem {
-            padding = box(0.px, 3.px)
+            padding = box(0.px)
             spacing = 5.px
         }
     }

--- a/src/main/kotlin/controller/EditorController.kt
+++ b/src/main/kotlin/controller/EditorController.kt
@@ -5,9 +5,9 @@ import javafx.beans.property.SimpleIntegerProperty
 import javafx.beans.property.SimpleListProperty
 import javafx.beans.property.SimpleObjectProperty
 import javafx.scene.control.IndexRange
-import main.kotlin.model.JournalEntry
-import main.kotlin.model.ReferencePosition
-import main.kotlin.model.Tag
+import main.kotlin.model.journal.JournalEntry
+import main.kotlin.model.journal.ReferencePosition
+import main.kotlin.model.journal.Tag
 import tornadofx.Controller
 import tornadofx.asObservable
 import tornadofx.onChange

--- a/src/main/kotlin/controller/JournalController.kt
+++ b/src/main/kotlin/controller/JournalController.kt
@@ -3,8 +3,8 @@ package main.kotlin.controller
 import javafx.beans.property.SimpleObjectProperty
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import main.kotlin.model.JournalEntry
 import main.kotlin.model.journal.Journal
+import main.kotlin.model.journal.JournalEntry
 import tornadofx.Controller
 import java.io.File
 import java.time.LocalDateTime

--- a/src/main/kotlin/controller/KeywordController.kt
+++ b/src/main/kotlin/controller/KeywordController.kt
@@ -1,7 +1,7 @@
 package main.kotlin.controller
 
 import javafx.beans.property.SimpleObjectProperty
-import main.kotlin.model.Tag
+import main.kotlin.model.journal.Tag
 import tornadofx.Controller
 
 class KeywordController : Controller() {

--- a/src/main/kotlin/controller/ReferencesController.kt
+++ b/src/main/kotlin/controller/ReferencesController.kt
@@ -2,10 +2,13 @@ package main.kotlin.controller
 
 import javafx.beans.property.SimpleMapProperty
 import javafx.beans.property.SimpleObjectProperty
+import javafx.scene.paint.Color
+import main.kotlin.model.journal.ReferenceType
 import main.kotlin.model.reference.*
 import org.jetbrains.exposed.sql.*
 import org.jetbrains.exposed.sql.transactions.transaction
 import tornadofx.Controller
+import tornadofx.asObservable
 import tornadofx.onChange
 import tornadofx.toObservable
 import java.io.File
@@ -24,6 +27,14 @@ class ReferencesController : Controller() {
     val authorMapping = SimpleMapProperty<Int, Author>()
     val referenceMapping = SimpleMapProperty<Int, Reference>()
     val selectedReference = SimpleObjectProperty<Reference>()
+
+    val selectedType = SimpleObjectProperty(ReferenceType.HIGHLIGHT)
+    val typeColors = SimpleMapProperty(
+        mapOf(
+            ReferenceType.HIGHLIGHT to Color.YELLOW,
+            ReferenceType.SUMMARY to Color.web("99cccc")
+        ).asObservable()
+    )
 
     init {
         referenceMapping.onChange {

--- a/src/main/kotlin/model/journal/Journal.kt
+++ b/src/main/kotlin/model/journal/Journal.kt
@@ -16,10 +16,6 @@ import kotlinx.serialization.descriptors.buildClassSerialDescriptor
 import kotlinx.serialization.descriptors.element
 import kotlinx.serialization.encoding.*
 import kotlinx.serialization.json.Json
-import main.kotlin.model.JournalEntry
-import main.kotlin.model.JournalEntrySerializer
-import main.kotlin.model.KeywordSerializer
-import main.kotlin.model.Tag
 import main.kotlin.model.reference.Reference
 import tornadofx.asObservable
 import tornadofx.cleanBind

--- a/src/main/kotlin/model/journal/JournalEntry.kt
+++ b/src/main/kotlin/model/journal/JournalEntry.kt
@@ -1,4 +1,4 @@
-package main.kotlin.model
+package main.kotlin.model.journal
 
 import javafx.beans.property.*
 import javafx.collections.ObservableList

--- a/src/main/kotlin/model/journal/JournalMeta.kt
+++ b/src/main/kotlin/model/journal/JournalMeta.kt
@@ -21,6 +21,9 @@ data class JournalMeta(val title: String = "") {
     val fileProperty = SimpleObjectProperty<File>()
 
     companion object {
+        /**
+         * Load only metadata of Journal JSON files, ignoring all other values of the Journal.
+         */
         fun load(file: File): JournalMeta {
             val format = Json { ignoreUnknownKeys = true }
             val journalMeta: JournalMeta = format.decodeFromString(file.readText())
@@ -28,6 +31,9 @@ data class JournalMeta(val title: String = "") {
             return journalMeta
         }
 
+        /**
+         * Create JournalMeta object with properties of journal and with the given file location.
+         */
         fun from(journal: Journal, file: File) = JournalMeta(journal.titleProperty.get()).also {
             it.fileProperty.set(file)
         }

--- a/src/main/kotlin/model/journal/Tag.kt
+++ b/src/main/kotlin/model/journal/Tag.kt
@@ -1,4 +1,4 @@
-package main.kotlin.model
+package main.kotlin.model.journal
 
 import javafx.beans.property.*
 import javafx.scene.paint.Color

--- a/src/main/kotlin/view/entry/EntryFragment.kt
+++ b/src/main/kotlin/view/entry/EntryFragment.kt
@@ -2,8 +2,8 @@ package main.kotlin.view.fragment
 
 import javafx.scene.layout.Priority
 import main.kotlin.Styles
-import main.kotlin.model.JournalEntry
-import main.kotlin.model.JournalEntryModel
+import main.kotlin.model.journal.JournalEntry
+import main.kotlin.model.journal.JournalEntryModel
 import main.kotlin.view.tag.tagbar
 import tornadofx.*
 

--- a/src/main/kotlin/view/main/EditorView.kt
+++ b/src/main/kotlin/view/main/EditorView.kt
@@ -9,8 +9,9 @@ import main.kotlin.JournalApp
 import main.kotlin.Styles
 import main.kotlin.controller.EditorController
 import main.kotlin.controller.JournalController
-import main.kotlin.model.JournalEntry
-import main.kotlin.model.ReferencePosition
+import main.kotlin.controller.ReferencesController
+import main.kotlin.model.journal.JournalEntry
+import main.kotlin.model.journal.ReferencePosition
 import main.kotlin.view.JournalView
 import main.kotlin.view.tag.tagbar
 import org.commonmark.parser.Parser
@@ -24,6 +25,7 @@ import java.time.Duration
 class EditorView : JournalView() {
     private val editorController: EditorController by inject()
     private val journalController: JournalController by inject()
+    private val referencesController: ReferencesController by inject()
 
     private val hoverDurationMillis = 200L
 
@@ -148,7 +150,7 @@ class EditorView : JournalView() {
                     val setStyle: (ReferencePosition) -> Unit = { referencePosition ->
                         val selectionImpl = SelectionImpl("${referencePosition.hashCode()}", area) { path ->
                             path.strokeWidth = 0.0
-                            path.fill = Styles.highlightColor
+                            path.fill = referencesController.typeColors[referencePosition.typeProperty.value]
                         }
 
                         if (area.text.length >= referencePosition.endProperty.get()) {

--- a/src/main/kotlin/view/main/MainView.kt
+++ b/src/main/kotlin/view/main/MainView.kt
@@ -2,6 +2,7 @@ package main.kotlin.view.main
 
 import main.kotlin.view.JournalView
 import main.kotlin.view.entry.EntriesView
+import main.kotlin.view.reference.ReferencesView
 import tornadofx.borderpane
 
 class MainView : JournalView() {

--- a/src/main/kotlin/view/reference/ReferencePositionFragment.kt
+++ b/src/main/kotlin/view/reference/ReferencePositionFragment.kt
@@ -1,18 +1,26 @@
 package main.kotlin.view.reference
 
+import javafx.geometry.Orientation
+import main.kotlin.Styles
 import main.kotlin.controller.ReferencesController
-import main.kotlin.model.NoteModel
-import main.kotlin.model.ReferencePosition
+import main.kotlin.model.journal.ReferencePosition
+import main.kotlin.model.journal.ReferencePositionModel
 import tornadofx.*
 
 class ReferencePositionFragment : ListCellFragment<ReferencePosition>() {
-    val entry = NoteModel(itemProperty)
+    val entry = ReferencePositionModel(itemProperty)
 
     val referencesController: ReferencesController by inject()
+
     val referencesView: ZoteroView by inject()
 
     override val root = vbox {
         hbox {
+            addClass(Styles.entryItem)
+            text(entry.type)
+
+            separator(Orientation.VERTICAL)
+
             text(entry.start)
             text("-")
             text(entry.end)

--- a/src/main/kotlin/view/reference/ReferencesView.kt
+++ b/src/main/kotlin/view/reference/ReferencesView.kt
@@ -1,13 +1,11 @@
-package main.kotlin.view.main
+package main.kotlin.view.reference
 
 import javafx.collections.ObservableList
 import javafx.scene.layout.Priority
 import main.kotlin.Styles
 import main.kotlin.controller.EditorController
-import main.kotlin.model.ReferencePosition
+import main.kotlin.model.journal.ReferencePosition
 import main.kotlin.view.JournalView
-import main.kotlin.view.reference.ReferencePositionFragment
-import main.kotlin.view.reference.ZoteroView
 import tornadofx.*
 
 class ReferencesView : JournalView() {

--- a/src/main/kotlin/view/reference/ZoteroView.kt
+++ b/src/main/kotlin/view/reference/ZoteroView.kt
@@ -3,7 +3,8 @@ package main.kotlin.view.reference
 import main.kotlin.Styles
 import main.kotlin.controller.EditorController
 import main.kotlin.controller.ReferencesController
-import main.kotlin.model.ReferencePosition
+import main.kotlin.model.journal.ReferencePosition
+import main.kotlin.model.journal.ReferenceType
 import main.kotlin.view.JournalView
 import tornadofx.*
 
@@ -61,22 +62,29 @@ class ZoteroView : JournalView() {
         }
 
         row {
-            button("+") {
-                disableWhen(
-                    editorController.isValidSelection.not()
-                        .or(editorController.isEditable.not())
-                        .or(referencesController.selectedReference.isNull)
-                )
-                action {
-                    editorController.current.get().referencesProperty.add(
-                        ReferencePosition(
-                            start = editorController.selectionBounds.get().start,
-                            end = editorController.selectionBounds.get().end,
-                            reference = referencesController.selectedReference.get()
-                        )
+            hbox {
+                addClass(Styles.buttons)
+
+                button("+") {
+                    disableWhen(
+                        editorController.isValidSelection.not()
+                            .or(editorController.isEditable.not())
+                            .or(referencesController.selectedReference.isNull)
                     )
-                    currentStage?.close()
+                    action {
+                        editorController.current.get().referencesProperty.add(
+                            ReferencePosition(
+                                start = editorController.selectionBounds.get().start,
+                                end = editorController.selectionBounds.get().end,
+                                reference = referencesController.selectedReference.get(),
+                                referenceType = referencesController.selectedType.get()
+                            )
+                        )
+                        currentStage?.close()
+                    }
                 }
+
+                combobox(referencesController.selectedType, ReferenceType.values().asList())
             }
         }
     }

--- a/src/main/kotlin/view/tag/EditableTagFragment.kt
+++ b/src/main/kotlin/view/tag/EditableTagFragment.kt
@@ -2,8 +2,8 @@ package main.kotlin.view.tag
 
 import javafx.scene.layout.Priority
 import main.kotlin.Styles
-import main.kotlin.model.Tag
-import main.kotlin.model.TagModel
+import main.kotlin.model.journal.Tag
+import main.kotlin.model.journal.TagModel
 import tornadofx.*
 
 class EditableTagFragment : ListCellFragment<Tag>() {

--- a/src/main/kotlin/view/tag/TagBar.kt
+++ b/src/main/kotlin/view/tag/TagBar.kt
@@ -10,8 +10,8 @@ import javafx.event.EventTarget
 import javafx.geometry.Insets
 import javafx.scene.layout.*
 import main.kotlin.Styles
-import main.kotlin.model.Tag
-import main.kotlin.model.TagModel
+import main.kotlin.model.journal.Tag
+import main.kotlin.model.journal.TagModel
 import tornadofx.*
 
 fun EventTarget.tagbar(values: ObservableValue<ObservableList<Tag>>, op: TagBar.() -> Unit = {}) =

--- a/src/main/kotlin/view/tag/TagView.kt
+++ b/src/main/kotlin/view/tag/TagView.kt
@@ -4,7 +4,7 @@ import main.kotlin.Styles
 import main.kotlin.controller.EditorController
 import main.kotlin.controller.JournalController
 import main.kotlin.controller.KeywordController
-import main.kotlin.model.Tag
+import main.kotlin.model.journal.Tag
 import main.kotlin.view.JournalView
 import tornadofx.*
 

--- a/src/test/kotlin/model/JournalEntryTest.kt
+++ b/src/test/kotlin/model/JournalEntryTest.kt
@@ -5,7 +5,7 @@ import io.kotest.matchers.shouldBe
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import main.kotlin.model.JournalEntry
+import main.kotlin.model.journal.JournalEntry
 import java.time.LocalDateTime
 import java.time.ZoneOffset
 

--- a/src/test/kotlin/model/JournalTest.kt
+++ b/src/test/kotlin/model/JournalTest.kt
@@ -5,9 +5,9 @@ import io.kotest.matchers.shouldBe
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import main.kotlin.model.JournalEntry
-import main.kotlin.model.Tag
 import main.kotlin.model.journal.Journal
+import main.kotlin.model.journal.JournalEntry
+import main.kotlin.model.journal.Tag
 import java.time.LocalDateTime
 import java.time.ZoneOffset
 import java.util.*

--- a/src/test/kotlin/model/ReferencePositionTest.kt
+++ b/src/test/kotlin/model/ReferencePositionTest.kt
@@ -5,7 +5,7 @@ import io.kotest.matchers.shouldBe
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import main.kotlin.model.ReferencePosition
+import main.kotlin.model.journal.ReferencePosition
 
 class ReferencePositionTest : FreeSpec({
     "a reference position" - {

--- a/src/test/kotlin/model/TagTest.kt
+++ b/src/test/kotlin/model/TagTest.kt
@@ -6,7 +6,7 @@ import javafx.scene.paint.Color
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import main.kotlin.model.Tag
+import main.kotlin.model.journal.Tag
 import java.util.*
 
 class TagTest : FreeSpec({


### PR DESCRIPTION
Not to be confused with the type of the reference itself.

In future, we might want to draw more elegant delimiters for summaries, and allow these to be editable (and non-volatile, so settings need to be store din the app directory).